### PR TITLE
Added missing MMS permission to EC2 instance profile

### DIFF
--- a/templates/ami.template
+++ b/templates/ami.template
@@ -444,6 +444,13 @@
                                             "Fn::Sub": "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/${ESDomain}/*"
                                         }
                                     ]
+                                },
+                                {
+                                    "Action": [
+                                        "aws-marketplace:MeterUsage"
+                                    ],
+                                    "Effect": "Allow",
+                                    "Resource": "*"
                                 }
                             ]
                         }


### PR DESCRIPTION
MP engineering have just spotted that billing was failing because of a missing permission.  This change will allow our billing component to talk on the hour every hour to the MMS.