### PR TITLE
Support 3 additional regions, support deploy to new VPC, restrict access to RDS from EC2, stipulate version of SQL Express & fixed CIDR regex pattern for RDP

### DIFF
--- a/scripts/install-join-ad.ps1
+++ b/scripts/install-join-ad.ps1
@@ -1,15 +1,15 @@
 [CmdletBinding()]
 param (
     [Parameter(Mandatory=$true)]
-    [string[]]$ip1,
+    [string]$ip1,
     [Parameter(Mandatory=$true)]
-    [string[]]$ip2,
+    [string]$ip2,
     [Parameter(Mandatory=$true)]
-    [string[]]$adDomain,
+    [string]$adDomain,
     [Parameter(Mandatory=$true)]
-    [string[]]$adAdminUser,
+    [string]$adAdminUser,
     [Parameter(Mandatory=$true)]
-    [string[]]$adAdminPassword
+    [string]$adAdminPassword
 )
 
 ### Join the domain

--- a/templates/ami-security.template
+++ b/templates/ami-security.template
@@ -30,7 +30,7 @@
     },
     "Parameters": {
         "RDPFrom": {
-            "AllowedPattern": "^(2[0-4]\\d|25[0-5]|1?\\d?\\d)(?:\\.(1?[0-9]{1,2})){3}\\/([1-9]|1[0-9]|2[0-9]|3[0-2])$",
+            "AllowedPattern": "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\\/(1[6-9]|2[0-8]|3[0-2]))$",
             "ConstraintDescription": "Must not be empty, must be valid IPv4 address with valid Mask Bit from 1-32, format of x.x.x.x/x",
             "Description": "Lockdown RDP access to EC2 instance from valid IPv4 address, e.g. 201.0.1.3/19",
             "Type": "String"
@@ -121,6 +121,14 @@
         "WebXFace": {
             "Value": {
                 "Ref": "WebXface"
+            }
+        },
+        "PrivateIp": {
+            "Value": {
+                "Fn::GetAtt": [
+                    "WebXface",
+                    "PrimaryPrivateIpAddress"
+                ]
             }
         }
     }

--- a/templates/ami.template
+++ b/templates/ami.template
@@ -444,6 +444,13 @@
                                             "Fn::Sub": "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/${ESDomain}/*"
                                         }
                                     ]
+                                },
+                                {
+                                    "Action": [
+                                        "aws-marketplace:MeterUsage"
+                                    ],
+                                    "Effect": "Allow",
+                                    "Resource": "*"
                                 }
                             ]
                         }

--- a/templates/ami.template
+++ b/templates/ami.template
@@ -328,14 +328,19 @@
             "Assertions": [
                 {
                     "Assert": {
-                        "Fn::Equals": [
+                        "Fn::Contains": [
+                            [
+                                "us-east-1",
+                                "us-west-2",
+                                "eu-central-1",
+                                "ap-southeast-2"
+                            ],
                             {
                                 "Ref": "AWS::Region"
-                            },
-                            "us-east-1"
+                            }
                         ]
                     },
-                    "AssertDescription": "Region must be US East (N. Virginia) - us-east-1"
+                    "AssertDescription": "Region must be either US East (N. Virginia) - us-east-1, US West (Oregon) - us-west-2, EU (Frankfurt) - eu-central-1, Asia Pacific (Sydney) - ap-southeast-2"
                 }
             ]
         }
@@ -344,6 +349,9 @@
         "AWSAMIRegionMap": {
             "us-east-1": {
                 "WS2016R2V1": "ami-73fd2d09"
+            },
+            "us-west-2": {
+                "WS2016R2V1": "ami-ace724d4"
             },
             "eu-central-1": {
                 "WS2016R2V1": "ami-10e45d7f"

--- a/templates/ami.template
+++ b/templates/ami.template
@@ -15,7 +15,8 @@
                         "SubnetID",
                         "ElasticIp",
                         "WebXface",
-                        "RDPFrom"
+                        "RDPFrom",
+                        "PrivateIp"
                     ]
                 },
                 {
@@ -132,6 +133,9 @@
                 },
                 "SubnetID": {
                     "default": "Subnet ID"
+                },                
+                "PrivateIp": {
+                    "default": "Private IP"
                 },
                 "VPCID": {
                     "default": "VPC ID"
@@ -304,7 +308,7 @@
         },
         "SubnetID": {
             "Description": "Subnet ID, must be same CIDR that was supplied when ElasticSearch was deployed",
-            "Type": "AWS::EC2::Subnet::Id"
+            "Type": "List<AWS::EC2::Subnet::Id>"
         },
         "VPCID": {
             "Description": "ID of your existing VPC for deployment",
@@ -313,6 +317,10 @@
         "WebXface": {
             "Type": "String",
             "Description": "Interface for web traffic"
+        },
+        "PrivateIp": {
+            "Type": "String",
+            "Description": "Private IP address to be allowed access to RDS"
         }
     },
     "Rules": {
@@ -346,6 +354,32 @@
         }
     },
     "Resources": {
+        "InstanceSecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+            "Properties": {
+                "GroupDescription": "Allow access from EC2 instance",
+                "VpcId": {"Ref": "VPCID"},
+                "SecurityGroupIngress": [{
+                    "IpProtocol": "tcp",
+                    "FromPort": "1433",
+                    "ToPort": "1433",
+                    "CidrIp": {"Fn::Sub": "${PrivateIp}/32"}
+                }],
+                "SecurityGroupEgress" : [{
+                    "IpProtocol": "tcp",
+                    "FromPort": "0",
+                    "ToPort": "0",
+                    "CidrIp": "0.0.0.0/0"
+                }]
+            }
+        },
+        "MyDBSubnetGroup": {
+            "Type": "AWS::RDS::DBSubnetGroup",
+            "Properties": {
+                "DBSubnetGroupDescription": "description",
+                "SubnetIds": {"Ref": "SubnetID"} 
+            }
+        },
         "SqlExpress": {
             "Type": "AWS::RDS::DBInstance",
             "DeletionPolicy": "Snapshot",
@@ -353,6 +387,7 @@
                 "AllocatedStorage": "100",
                 "DBInstanceClass": "db.t2.medium",
                 "Engine": "sqlserver-ex",
+                "EngineVersion": "13.00.4466.4.v1",
                 "Iops": "1000",
                 "MasterUsername": {
                     "Ref": "DBAdminUser"
@@ -360,7 +395,13 @@
                 "MasterUserPassword": {
                     "Ref": "DBAdminPassword"
                 },
-                "BackupRetentionPeriod": "0"
+                "BackupRetentionPeriod": "0",
+                "DBSubnetGroupName": {
+                    "Ref": "MyDBSubnetGroup"
+                },
+                "VPCSecurityGroups": [{
+                    "Ref": "InstanceSecurityGroup"
+                }]
             }
         },
         "RootRole": {

--- a/templates/evaluate-datastreaming-master.template
+++ b/templates/evaluate-datastreaming-master.template
@@ -454,14 +454,19 @@
             "Assertions": [
                 {
                     "Assert": {
-                        "Fn::Equals": [
+                        "Fn::Contains": [
+                            [
+                                "us-east-1",
+                                "us-west-2",
+                                "eu-central-1",
+                                "ap-southeast-2"
+                            ],
                             {
                                 "Ref": "AWS::Region"
-                            },
-                            "us-east-1"
+                            }
                         ]
                     },
-                    "AssertDescription": "Region must be US East (N. Virginia) - us-east-1"
+                    "AssertDescription": "Region must be either US East (N. Virginia) - us-east-1, US West (Oregon) - us-west-2, EU (Frankfurt) - eu-central-1, Asia Pacific (Sydney) - ap-southeast-2"
                 }
             ]
         },

--- a/templates/evaluate-datastreaming-master.template
+++ b/templates/evaluate-datastreaming-master.template
@@ -647,7 +647,17 @@
                         "Ref": "S3EvaluateBucket"
                     },
                     "SubnetID": {
-                        "Fn::GetAtt": "VPCStack.Outputs.PublicSubnet1ID"
+                        "Fn::Join": [
+                            ",",
+                            [
+                                {
+                                    "Fn::GetAtt": "VPCStack.Outputs.PublicSubnet1ID"
+                                },
+                                {
+                                    "Fn::GetAtt": "VPCStack.Outputs.PublicSubnet2ID"
+                                }
+                            ]
+                        ]
                     },
                     "VPCID": {
                         "Fn::GetAtt": "VPCStack.Outputs.VPCID"

--- a/templates/evaluate-datastreaming.template
+++ b/templates/evaluate-datastreaming.template
@@ -32,8 +32,7 @@
                     },
                     "Parameters": [
                         "InstanceType",
-                        "RDPFrom",
-                        "SubnetID"
+                        "RDPFrom"
                     ]
                 },
                 {
@@ -169,9 +168,6 @@
                 },
                 "S3EvaluateBucket": {
                     "default": "S3 Evaluate Bucket"
-                },
-                "SubnetID": {
-                    "default": "Subnet ID"
                 },
                 "VPCID": {
                     "default": "VPC ID"
@@ -408,10 +404,6 @@
             "MinLength": "3",
             "Type": "String"
         },
-        "SubnetID": {
-            "Description": "Subnet ID, must be same CIDR that was supplied when ElasticSearch was deployed",
-            "Type": "AWS::EC2::Subnet::Id"
-        },
         "VPCID": {
             "Description": "ID of your existing VPC for deployment",
             "Type": "AWS::EC2::VPC::Id"
@@ -543,7 +535,12 @@
                         "Ref": "VPCID"
                     },
                     "SubnetID": {
-                        "Ref": "SubnetID"
+                        "Fn::Join": [
+                            ",",
+                            {
+                                "Ref": "PublicSubnetID"
+                            }
+                        ]
                     },
                     "DBAdminUser": {
                         "Ref": "DBAdminUser"

--- a/templates/evaluate-datastreaming.template
+++ b/templates/evaluate-datastreaming.template
@@ -414,14 +414,19 @@
             "Assertions": [
                 {
                     "Assert": {
-                        "Fn::Equals": [
+                        "Fn::Contains": [
+                            [
+                                "us-east-1",
+                                "us-west-2",
+                                "eu-central-1",
+                                "ap-southeast-2"
+                            ],
                             {
                                 "Ref": "AWS::Region"
-                            },
-                            "us-east-1"
+                            }
                         ]
                     },
-                    "AssertDescription": "Region must be US East (N. Virginia) - us-east-1"
+                    "AssertDescription": "Region must be either US East (N. Virginia) - us-east-1, US West (Oregon) - us-west-2, EU (Frankfurt) - eu-central-1, Asia Pacific (Sydney) - ap-southeast-2"
                 }
             ]
         },

--- a/templates/evaluate.template
+++ b/templates/evaluate.template
@@ -362,14 +362,19 @@
             "Assertions": [
                 {
                     "Assert": {
-                        "Fn::Equals": [
+                        "Fn::Contains": [
+                            [
+                                "us-east-1",
+                                "us-west-2",
+                                "eu-central-1",
+                                "ap-southeast-2"
+                            ],
                             {
                                 "Ref": "AWS::Region"
-                            },
-                            "us-east-1"
+                            }
                         ]
                     },
-                    "AssertDescription": "Region must be US East (N. Virginia) - us-east-1"
+                    "AssertDescription": "Region must be either US East (N. Virginia) - us-east-1, US West (Oregon) - us-west-2, EU (Frankfurt) - eu-central-1, Asia Pacific (Sydney) - ap-southeast-2"
                 }
             ]
         }

--- a/templates/evaluate.template
+++ b/templates/evaluate.template
@@ -349,8 +349,8 @@
             "Type": "String"
         },
         "SubnetID": {
-            "Description": "Subnet ID, must be same CIDR that was supplied when ElasticSearch was deployed",
-            "Type": "AWS::EC2::Subnet::Id"
+            "Description": "Must select 2 or more. 1st is required by EC2 instance. All are required by RDS Subnet Group",
+            "Type": "List<AWS::EC2::Subnet::Id>"
         },
         "VPCID": {
             "Description": "ID of your existing VPC for deployment",
@@ -389,7 +389,7 @@
                         "Ref": "VPCID"
                     },
                     "SubnetID": {
-                        "Ref": "SubnetID"
+                        "Fn::Select": ["0", {"Ref": "SubnetID"}]
                     }
                 }
             }
@@ -473,7 +473,12 @@
                         "Ref": "VPCID"
                     },
                     "SubnetID": {
-                        "Ref": "SubnetID"
+                        "Fn::Join": [
+                            ",",
+                            {
+                                "Ref": "SubnetID"
+                            }
+                        ]
                     },
                     "DBAdminUser": {
                         "Ref": "DBAdminUser"
@@ -500,6 +505,12 @@
                         "Fn::GetAtt": [
                             "AMISecurityStack",
                             "Outputs.WebXFace"
+                        ]
+                    },
+                    "PrivateIp": {
+                        "Fn::GetAtt": [
+                            "AMISecurityStack",
+                            "Outputs.PrivateIp"
                         ]
                     },
                     "ElasticIp": {


### PR DESCRIPTION
Features & fixes:
- Support 3 additional regions (us-west-2, eu-central & ap-southeast-2)
- Support deploy option to new VPC (relating to RDS SG)
- Restrict access to RDS from EC2 (improved security)
- Stipulate version of SQL Express (driver on AMI only supports up to SQL Server 2016)
- Fixed CIDR regex pattern for RDP (rejected for some ranges)
- Fixed issue with cmdlet parameters (failed to install db if username or password contains particular chars)